### PR TITLE
Format R code

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -113,7 +113,8 @@ To conduct the analysis in R, we can use the ``BJSM_binary`` function. Users spe
 BJSM_dose_result <- BJSM_binary(
   data = data_dose, prior_dist = c("beta", "gamma"),
   pi_prior = c(3, 17), normal.par = c(0.2, 100), beta_prior = c(2, 2),
-  n_MCMC_chain = 2, n.adapt = 1000, BURN.IN = 10000, MCMC_SAMPLE = 60000, ci = 0.95
+  n_MCMC_chain = 2, n.adapt = 1000, BURN.IN = 10000,
+  MCMC_SAMPLE = 60000, ci = 0.95
 )
 summary(BJSM_dose_result)
 ```


### PR DESCRIPTION
Another editorial comment on the [JOSS submission](https://github.com/openjournals/joss-reviews/issues/6971).

Add an extra linebreak to get the R code inside the margins.